### PR TITLE
Remove block interval check for prunner

### DIFF
--- a/informative-indexer/cmd/prunner/cmd.go
+++ b/informative-indexer/cmd/prunner/cmd.go
@@ -8,15 +8,14 @@ import (
 )
 
 const (
-	FlagDBConnectionString   = "db"
-	FlagBackupBucketName     = "backup-bucket-name"
-	FlagBackupFilePrefix     = "backup-file-prefix"
-	FlagPruningKeepBlock     = "pruning-keep-block"
-	FlagPruningBlockInterval = "pruning-block-interval"
-	FlagPruningInterval      = "pruning-interval"
-	FlagChain                = "chain"
-	FlagEnvironment          = "environment"
-	FlagCommitSHA            = "commit-sha"
+	FlagDBConnectionString = "db"
+	FlagBackupBucketName   = "backup-bucket-name"
+	FlagBackupFilePrefix   = "backup-file-prefix"
+	FlagPruningKeepBlock   = "pruning-keep-block"
+	FlagPruningInterval    = "pruning-interval"
+	FlagChain              = "chain"
+	FlagEnvironment        = "environment"
+	FlagCommitSHA          = "commit-sha"
 )
 
 func PruneCmd() *cobra.Command {
@@ -29,22 +28,20 @@ func PruneCmd() *cobra.Command {
 			backupBucketName, _ := cmd.Flags().GetString(FlagBackupBucketName)
 			filePrefix, _ := cmd.Flags().GetString(FlagBackupFilePrefix)
 			pruningKeepBlock, _ := cmd.Flags().GetUint64(FlagPruningKeepBlock)
-			pruningBlockInterval, _ := cmd.Flags().GetUint64(FlagPruningBlockInterval)
 			pruningInterval, _ := cmd.Flags().GetUint64(FlagPruningInterval)
 			chain, _ := cmd.Flags().GetString(FlagChain)
 			environment, _ := cmd.Flags().GetString(FlagEnvironment)
 			commitSHA, _ := cmd.Flags().GetString(FlagCommitSHA)
 
 			p, err := prunner.NewPrunner(&prunner.PrunnerConfig{
-				DBConnectionString:   dbConnectionString,
-				BackupBucketName:     backupBucketName,
-				BackupFilePrefix:     filePrefix,
-				PruningKeepBlock:     int64(pruningKeepBlock),
-				PruningBlockInterval: int64(pruningBlockInterval),
-				PruningInterval:      int64(pruningInterval),
-				Chain:                chain,
-				Environment:          environment,
-				CommitSHA:            commitSHA,
+				DBConnectionString: dbConnectionString,
+				BackupBucketName:   backupBucketName,
+				BackupFilePrefix:   filePrefix,
+				PruningKeepBlock:   int64(pruningKeepBlock),
+				PruningInterval:    int64(pruningInterval),
+				Chain:              chain,
+				Environment:        environment,
+				CommitSHA:          commitSHA,
 			})
 
 			if err != nil {
@@ -62,11 +59,6 @@ func PruneCmd() *cobra.Command {
 		pruningKeepBlock = 500000
 	}
 
-	pruningBlockInterval, err := strconv.ParseInt(os.Getenv("PRUNING_BLOCK_INTERVAL"), 10, 64)
-	if err != nil {
-		pruningBlockInterval = 100000
-	}
-
 	pruningInterval, err := strconv.ParseInt(os.Getenv("PRUNING_INTERVAL"), 10, 64)
 	{
 		if err != nil {
@@ -78,7 +70,6 @@ func PruneCmd() *cobra.Command {
 	cmd.Flags().String(FlagBackupBucketName, os.Getenv("BACKUP_BUCKET_NAME"), "Name of the backup bucket")
 	cmd.Flags().String(FlagBackupFilePrefix, os.Getenv("BACKUP_FILE_PREFIX"), "Prefix for backup files")
 	cmd.Flags().Uint64(FlagPruningKeepBlock, uint64(pruningKeepBlock), "Number of blocks to keep in the db")
-	cmd.Flags().Uint64(FlagPruningBlockInterval, uint64(pruningBlockInterval), "Interval for pruning blocks, specified in block height")
 	cmd.Flags().Uint64(FlagPruningInterval, uint64(pruningInterval), "Pruning interval specified in days")
 	cmd.Flags().String(FlagChain, os.Getenv("CHAIN"), "Chain ID to prune")
 	cmd.Flags().String(FlagEnvironment, os.Getenv("ENVIRONMENT"), "Environment")

--- a/informative-indexer/prunner/prunner.go
+++ b/informative-indexer/prunner/prunner.go
@@ -27,15 +27,14 @@ type Prunner struct {
 }
 
 type PrunnerConfig struct {
-	DBConnectionString   string
-	BackupBucketName     string
-	BackupFilePrefix     string
-	PruningKeepBlock     int64
-	PruningBlockInterval int64
-	PruningInterval      int64
-	Chain                string
-	Environment          string
-	CommitSHA            string
+	DBConnectionString string
+	BackupBucketName   string
+	BackupFilePrefix   string
+	PruningKeepBlock   int64
+	PruningInterval    int64
+	Chain              string
+	Environment        string
+	CommitSHA          string
 }
 
 func NewPrunner(config *PrunnerConfig) (*Prunner, error) {
@@ -84,17 +83,6 @@ func (p *Prunner) StartPruning(signalCtx context.Context) {
 }
 
 func (p *Prunner) pruningTable(ctx context.Context, tableName string) error {
-	rows, err := db.GetRowCount(ctx, p.dbClient, tableName)
-	if err != nil {
-		logger.Error().Msgf("DB: Error getting row count: %v", err)
-		return fmt.Errorf("unable to get row count for table %s: %w", tableName, err)
-	}
-
-	if rows <= p.config.PruningBlockInterval {
-		logger.Info().Msgf("Pruning not required for table %s: # of rows are below the block interval.", tableName)
-		return nil
-	}
-
 	height, err := db.GetLatestBlockHeight(ctx, p.dbClient)
 	if err != nil {
 		return fmt.Errorf("DB: failed to get latest block height: %w", err)

--- a/informative-indexer/run.sh
+++ b/informative-indexer/run.sh
@@ -75,7 +75,6 @@ task__prune() {
     --backup-bucket-name ${chain}-local-core-informative-data-backup \
     --backup-file-prefix events \
     --pruning-keep-block 10 \
-    --pruning-block-interval 10 \
     --pruning-interval 1 \
     --chain $chain \
     --environment local


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed `pruning-block-interval` configuration option from pruning process
	- Simplified pruning configuration and logic
	- Streamlined pruning decision-making to focus on block height and blocks to keep

- **Chores**
	- Updated command-line interface to remove deprecated pruning parameter
	- Cleaned up related configuration and script settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->