### PR TITLE
fix: update prunner to prune move_events.

### DIFF
--- a/informative-indexer/db/db.go
+++ b/informative-indexer/db/db.go
@@ -146,6 +146,8 @@ func GetRowsToPruneByBlockHeight(ctx context.Context, dbClient Queryable, table 
 		t = TransactionEvent{}
 	} else if table == "finalize_block_events" {
 		t = FinalizeBlockEvent{}
+	} else if table == "move_events" {
+		t = MoveEvent{}
 	}
 
 	columns := getColumns(t)

--- a/informative-indexer/db/valid_tables.go
+++ b/informative-indexer/db/valid_tables.go
@@ -3,6 +3,7 @@ package db
 var validTableNames = []string{
 	"transaction_events",
 	"finalize_block_events",
+	"move_events",
 }
 
 func isValidTableName(tableName string) bool {

--- a/informative-indexer/prunner/prunner.go
+++ b/informative-indexer/prunner/prunner.go
@@ -140,6 +140,12 @@ func fetchRowsToPrune(ctx context.Context, dbClient db.Queryable, tableName stri
 			if err != nil {
 				return nil, err
 			}
+		} else if tableName == "move_events" {
+			eventResult := db.MoveEvent{}
+			row, err = eventResult.Unmarshal(rows)
+			if err != nil {
+				return nil, err
+			}
 		}
 		result = append(result, row)
 	}


### PR DESCRIPTION
Update prunner to prune move_events table. Create `move_events` folder under the `events_backups` bucket before prune.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for pruning `move_events` table in the database
	- Expanded valid table names to include `move_events`

- **Improvements**
	- Enhanced database row pruning functionality to handle move event data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->