### PR TITLE
chore: bump movevm.

### DIFF
--- a/dockerfiles/Dockerfile.informative
+++ b/dockerfiles/Dockerfile.informative
@@ -7,7 +7,7 @@ RUN go build -o /informative-indexer.bin .
 
 FROM ubuntu:22.04
 
-ENV MOVEVM_VERSION=v0.6.1
+ENV MOVEVM_VERSION=v0.7.0
 
 RUN apt-get update && apt-get install -y ca-certificates wget
 

--- a/informative-indexer/go.mod
+++ b/informative-indexer/go.mod
@@ -139,7 +139,7 @@ require (
 	github.com/iancoleman/strcase v0.3.0 // indirect
 	github.com/improbable-eng/grpc-web v0.15.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/initia-labs/movevm v0.6.1 // indirect
+	github.com/initia-labs/movevm v0.7.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/informative-indexer/go.sum
+++ b/informative-indexer/go.sum
@@ -629,8 +629,8 @@ github.com/initia-labs/cometbft v0.0.0-20241106155049-4698d4a37fe1 h1:Hqxf4a6PfC
 github.com/initia-labs/cometbft v0.0.0-20241106155049-4698d4a37fe1/go.mod h1:+wh6ap6xctVG+JOHwbl8pPKZ0GeqdPYqISu7F4b43cQ=
 github.com/initia-labs/initia v0.6.3 h1:1UuIE8hlavmnfyE4lQ6bTvgUTZFLUMIoccrErxhvFuA=
 github.com/initia-labs/initia v0.6.3/go.mod h1:Uj1GRFU+9VHiKa4nJ4LYz/zVlwd8iETryqfu8bdATrU=
-github.com/initia-labs/movevm v0.6.1 h1:g+nUX289tou8HaHkwvZIE7KzhVAi+fykpGORItw8j0E=
-github.com/initia-labs/movevm v0.6.1/go.mod h1:sj/kXD7mUQASqogPTjqltIr4Uid3xxnlcbfiFvvqeXA=
+github.com/initia-labs/movevm v0.7.0 h1:wi7LT12afxTTa2Tqwcndc4LRtS0mzossGrVNiUvs/aw=
+github.com/initia-labs/movevm v0.7.0/go.mod h1:sj/kXD7mUQASqogPTjqltIr4Uid3xxnlcbfiFvvqeXA=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=


### PR DESCRIPTION
bump movevm from 0.6.1 to 0.7.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

The latest update incorporates key maintenance improvements that help ensure a reliable experience with our system. The core dependency has been refreshed to leverage the latest stable enhancements, and the related configuration has been updated accordingly.

- **Chores**
  - Upgraded the MoveVM dependency to version v0.7.0.
  - Revised configuration settings to support the new version while maintaining compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->