### PR TITLE
fix: inactive and voting times

### DIFF
--- a/informative-indexer/flusher/utils/proposal.go
+++ b/informative-indexer/flusher/utils/proposal.go
@@ -46,5 +46,10 @@ func IsExpeditedRejected(value string) bool {
 }
 
 func IsProposalResolved(status db.ProposalStatus) bool {
-	return status == db.ProposalStatusPassed || status == db.ProposalStatusRejected || status == db.ProposalStatusFailed || status == db.ProposalStatusCancelled
+	return status == db.ProposalStatusInactive || status == db.ProposalStatusPassed || status == db.ProposalStatusRejected || status == db.ProposalStatusFailed || status == db.ProposalStatusCancelled
+}
+
+// TODO: handle with db.ProposalStatus instead
+func IsProposalPruned(status string) bool {
+	return status == string(db.ProposalStatusInactive) || status == string(db.ProposalStatusCancelled)
 }


### PR DESCRIPTION
- https://linear.app/initia-labs/issue/QA-440/scan-failed-block-and-time-of-proposal-failure-because-of-not-enough
- https://linear.app/initia-labs/issue/QA-413/scan-api-get-proposals-returns-data-items-with-incorrect-timestamp