### PR TITLE
chore: fix dockerfile

### DIFF
--- a/dockerfiles/Dockerfile.informative
+++ b/dockerfiles/Dockerfile.informative
@@ -9,7 +9,7 @@ FROM alpine:3.22
 
 ENV MOVEVM_VERSION=v0.7.0
 
-RUN apt-get update && apt-get install -y ca-certificates wget
+RUN apk update && apk add --no-cache ca-certificates wget
 
 WORKDIR /informative-indexer
 


### PR DESCRIPTION
use apk instead of apt