### PR TITLE
feat(indexer): add version validation in parseBlockAndRebalanceRPCClient

### DIFF
--- a/generic-indexer/indexer/indexer.go
+++ b/generic-indexer/indexer/indexer.go
@@ -245,6 +245,10 @@ func (f *Indexer) parseBlockAndRebalanceRPCClient(parentCtx context.Context, blo
 		return blockMsg, err
 	}
 
+	if blockMsg.Version != 0 {
+		return blockMsg, fmt.Errorf("invalid version: %d", blockMsg.Version)
+	}
+
 	if f.config.RebalanceInterval != 0 && blockMsg.Height%f.config.RebalanceInterval == 0 {
 		err := f.rpcClient.Rebalance(ctx)
 		if err != nil {

--- a/pkg/mq/kafka_msg.go
+++ b/pkg/mq/kafka_msg.go
@@ -41,6 +41,10 @@ type BlockResultMsg struct {
 	FinalizeBlockEvents      []abci.Event  `json:"finalize_block_events"`
 	LastCommit               *types.Commit `json:"last_commit"`
 	ProposerConsensusAddress string        `json:"proposer_consensus_address"`
+
+	// version is used to track the version of the message
+	// consumer can use this to track the version of the message and handle the message accordingly
+	Version int64 `json:"version"`
 }
 
 type ClaimCheckMsg struct {
@@ -72,6 +76,9 @@ func NewBlockResultMsgBytes(block *coretypes.ResultBlock, blockResult *coretypes
 		FinalizeBlockEvents:      blockResult.FinalizeBlockEvents,
 		LastCommit:               block.Block.LastCommit,
 		ProposerConsensusAddress: consensusAddress,
+
+		// version is used to track the version of the message
+		Version: 0,
 	}
 
 	v, err := json.Marshal(msg)


### PR DESCRIPTION
- Introduced a check for the block message version in the parseBlockAndRebalanceRPCClient function to ensure it is set to 0, returning an error if it is not.
- Added a new Version field to the BlockResultMsg struct to track message versions, allowing consumers to handle messages accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced message versioning for block result messages with a default version of 0, enabling clearer compatibility management and forward extensibility.

- Bug Fixes
  - Added validation to reject unsupported message versions, ensuring only version 0 is processed. This prevents unintended processing paths and reduces risk of inconsistent indexing behavior and noisy logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->