### PR TITLE
Feat: add get txs by account

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -2105,7 +2105,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.TxsResponse"
+                            "$ref": "#/definitions/dto.TxsModelResponse"
                         }
                     },
                     "400": {
@@ -2132,7 +2132,7 @@ const docTemplate = `{
                 "tags": [
                     "Transaction"
                 ],
-                "summary": "Get transaction by account address",
+                "summary": "Get transactions by account address",
                 "parameters": [
                     {
                         "type": "string",
@@ -2172,12 +2172,9 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "Transaction list",
+                        "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/dto.TxResponse"
-                            }
+                            "$ref": "#/definitions/dto.TxsResponse"
                         }
                     },
                     "400": {
@@ -2253,7 +2250,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.TxResponse"
+                            "$ref": "#/definitions/dto.TxByHashResponse"
                         }
                     },
                     "400": {
@@ -4054,6 +4051,49 @@ const docTemplate = `{
                 }
             }
         },
+        "dto.TxByHashResponse": {
+            "type": "object",
+            "properties": {
+                "tx": {
+                    "$ref": "#/definitions/dto.Tx"
+                },
+                "tx_response": {
+                    "$ref": "#/definitions/dto.TxResponse"
+                }
+            }
+        },
+        "dto.TxModel": {
+            "type": "object",
+            "properties": {
+                "hash": {
+                    "type": "string"
+                },
+                "height": {
+                    "type": "integer"
+                },
+                "is_ibc": {
+                    "type": "boolean"
+                },
+                "is_opinit": {
+                    "type": "boolean"
+                },
+                "is_send": {
+                    "type": "boolean"
+                },
+                "messages": {
+                    "type": "object"
+                },
+                "sender": {
+                    "type": "string"
+                },
+                "success": {
+                    "type": "boolean"
+                },
+                "timestamp": {
+                    "type": "string"
+                }
+            }
+        },
         "dto.TxResponse": {
             "type": "object",
             "properties": {
@@ -4102,6 +4142,20 @@ const docTemplate = `{
                 },
                 "txhash": {
                     "type": "string"
+                }
+            }
+        },
+        "dto.TxsModelResponse": {
+            "type": "object",
+            "properties": {
+                "pagination": {
+                    "$ref": "#/definitions/dto.PaginationResponse"
+                },
+                "txs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dto.TxModel"
+                    }
                 }
             }
         },

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -2123,6 +2123,78 @@ const docTemplate = `{
                 }
             }
         },
+        "/indexer/tx/v1/txs/by_account/{accountAddress}": {
+            "get": {
+                "description": "Retrieve transactions by account address",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Transaction"
+                ],
+                "summary": "Get transaction by account address",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Account address",
+                        "name": "accountAddress",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Offset for pagination",
+                        "name": "pagination.offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 10,
+                        "description": "Limit for pagination",
+                        "name": "pagination.limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Reverse order for pagination",
+                        "name": "pagination.reverse",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Count total number of transactions",
+                        "name": "pagination.count_total",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Transaction list",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/dto.TxResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apperror.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apperror.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/indexer/tx/v1/txs/count": {
             "get": {
                 "description": "Retrieve the total number of transactions",
@@ -3982,38 +4054,6 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.TxModel": {
-            "type": "object",
-            "properties": {
-                "hash": {
-                    "type": "string"
-                },
-                "height": {
-                    "type": "integer"
-                },
-                "is_ibc": {
-                    "type": "boolean"
-                },
-                "is_opinit": {
-                    "type": "boolean"
-                },
-                "is_send": {
-                    "type": "boolean"
-                },
-                "messages": {
-                    "type": "object"
-                },
-                "sender": {
-                    "type": "string"
-                },
-                "success": {
-                    "type": "boolean"
-                },
-                "timestamp": {
-                    "type": "string"
-                }
-            }
-        },
         "dto.TxResponse": {
             "type": "object",
             "properties": {
@@ -4074,7 +4114,7 @@ const docTemplate = `{
                 "txs": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.TxModel"
+                        "$ref": "#/definitions/dto.TxResponse"
                     }
                 }
             }

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -2098,7 +2098,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.TxsResponse"
+                            "$ref": "#/definitions/dto.TxsModelResponse"
                         }
                     },
                     "400": {
@@ -2125,7 +2125,7 @@
                 "tags": [
                     "Transaction"
                 ],
-                "summary": "Get transaction by account address",
+                "summary": "Get transactions by account address",
                 "parameters": [
                     {
                         "type": "string",
@@ -2165,12 +2165,9 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Transaction list",
+                        "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/dto.TxResponse"
-                            }
+                            "$ref": "#/definitions/dto.TxsResponse"
                         }
                     },
                     "400": {
@@ -2246,7 +2243,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/dto.TxResponse"
+                            "$ref": "#/definitions/dto.TxByHashResponse"
                         }
                     },
                     "400": {
@@ -4047,6 +4044,49 @@
                 }
             }
         },
+        "dto.TxByHashResponse": {
+            "type": "object",
+            "properties": {
+                "tx": {
+                    "$ref": "#/definitions/dto.Tx"
+                },
+                "tx_response": {
+                    "$ref": "#/definitions/dto.TxResponse"
+                }
+            }
+        },
+        "dto.TxModel": {
+            "type": "object",
+            "properties": {
+                "hash": {
+                    "type": "string"
+                },
+                "height": {
+                    "type": "integer"
+                },
+                "is_ibc": {
+                    "type": "boolean"
+                },
+                "is_opinit": {
+                    "type": "boolean"
+                },
+                "is_send": {
+                    "type": "boolean"
+                },
+                "messages": {
+                    "type": "object"
+                },
+                "sender": {
+                    "type": "string"
+                },
+                "success": {
+                    "type": "boolean"
+                },
+                "timestamp": {
+                    "type": "string"
+                }
+            }
+        },
         "dto.TxResponse": {
             "type": "object",
             "properties": {
@@ -4095,6 +4135,20 @@
                 },
                 "txhash": {
                     "type": "string"
+                }
+            }
+        },
+        "dto.TxsModelResponse": {
+            "type": "object",
+            "properties": {
+                "pagination": {
+                    "$ref": "#/definitions/dto.PaginationResponse"
+                },
+                "txs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/dto.TxModel"
+                    }
                 }
             }
         },

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -2116,6 +2116,78 @@
                 }
             }
         },
+        "/indexer/tx/v1/txs/by_account/{accountAddress}": {
+            "get": {
+                "description": "Retrieve transactions by account address",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Transaction"
+                ],
+                "summary": "Get transaction by account address",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Account address",
+                        "name": "accountAddress",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "default": 0,
+                        "description": "Offset for pagination",
+                        "name": "pagination.offset",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 10,
+                        "description": "Limit for pagination",
+                        "name": "pagination.limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Reverse order for pagination",
+                        "name": "pagination.reverse",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Count total number of transactions",
+                        "name": "pagination.count_total",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Transaction list",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/dto.TxResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/apperror.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/apperror.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/indexer/tx/v1/txs/count": {
             "get": {
                 "description": "Retrieve the total number of transactions",
@@ -3975,38 +4047,6 @@
                 }
             }
         },
-        "dto.TxModel": {
-            "type": "object",
-            "properties": {
-                "hash": {
-                    "type": "string"
-                },
-                "height": {
-                    "type": "integer"
-                },
-                "is_ibc": {
-                    "type": "boolean"
-                },
-                "is_opinit": {
-                    "type": "boolean"
-                },
-                "is_send": {
-                    "type": "boolean"
-                },
-                "messages": {
-                    "type": "object"
-                },
-                "sender": {
-                    "type": "string"
-                },
-                "success": {
-                    "type": "boolean"
-                },
-                "timestamp": {
-                    "type": "string"
-                }
-            }
-        },
         "dto.TxResponse": {
             "type": "object",
             "properties": {
@@ -4067,7 +4107,7 @@
                 "txs": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.TxModel"
+                        "$ref": "#/definitions/dto.TxResponse"
                     }
                 }
             }

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -851,27 +851,6 @@ definitions:
           type: string
         type: array
     type: object
-  dto.TxModel:
-    properties:
-      hash:
-        type: string
-      height:
-        type: integer
-      is_ibc:
-        type: boolean
-      is_opinit:
-        type: boolean
-      is_send:
-        type: boolean
-      messages:
-        type: object
-      sender:
-        type: string
-      success:
-        type: boolean
-      timestamp:
-        type: string
-    type: object
   dto.TxResponse:
     properties:
       code:
@@ -912,7 +891,7 @@ definitions:
         $ref: '#/definitions/dto.PaginationResponse'
       txs:
         items:
-          $ref: '#/definitions/dto.TxModel'
+          $ref: '#/definitions/dto.TxResponse'
         type: array
     type: object
   dto.ValidatorAnswerCountsResponse:
@@ -2603,6 +2582,55 @@ paths:
           schema:
             $ref: '#/definitions/apperror.Response'
       summary: Get transaction by hash
+      tags:
+      - Transaction
+  /indexer/tx/v1/txs/by_account/{accountAddress}:
+    get:
+      description: Retrieve transactions by account address
+      parameters:
+      - description: Account address
+        in: path
+        name: accountAddress
+        required: true
+        type: string
+      - default: 0
+        description: Offset for pagination
+        in: query
+        name: pagination.offset
+        type: integer
+      - default: 10
+        description: Limit for pagination
+        in: query
+        name: pagination.limit
+        type: integer
+      - default: false
+        description: Reverse order for pagination
+        in: query
+        name: pagination.reverse
+        type: boolean
+      - default: false
+        description: Count total number of transactions
+        in: query
+        name: pagination.count_total
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Transaction list
+          schema:
+            items:
+              $ref: '#/definitions/dto.TxResponse'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/apperror.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/apperror.Response'
+      summary: Get transaction by account address
       tags:
       - Transaction
   /indexer/tx/v1/txs/count:

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -851,6 +851,34 @@ definitions:
           type: string
         type: array
     type: object
+  dto.TxByHashResponse:
+    properties:
+      tx:
+        $ref: '#/definitions/dto.Tx'
+      tx_response:
+        $ref: '#/definitions/dto.TxResponse'
+    type: object
+  dto.TxModel:
+    properties:
+      hash:
+        type: string
+      height:
+        type: integer
+      is_ibc:
+        type: boolean
+      is_opinit:
+        type: boolean
+      is_send:
+        type: boolean
+      messages:
+        type: object
+      sender:
+        type: string
+      success:
+        type: boolean
+      timestamp:
+        type: string
+    type: object
   dto.TxResponse:
     properties:
       code:
@@ -884,6 +912,15 @@ definitions:
         $ref: '#/definitions/dto.Tx'
       txhash:
         type: string
+    type: object
+  dto.TxsModelResponse:
+    properties:
+      pagination:
+        $ref: '#/definitions/dto.PaginationResponse'
+      txs:
+        items:
+          $ref: '#/definitions/dto.TxModel'
+        type: array
     type: object
   dto.TxsResponse:
     properties:
@@ -2543,7 +2580,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.TxsResponse'
+            $ref: '#/definitions/dto.TxsModelResponse'
         "400":
           description: Bad Request
           schema:
@@ -2572,7 +2609,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/dto.TxResponse'
+            $ref: '#/definitions/dto.TxByHashResponse'
         "400":
           description: Bad Request
           schema:
@@ -2617,11 +2654,9 @@ paths:
       - application/json
       responses:
         "200":
-          description: Transaction list
+          description: OK
           schema:
-            items:
-              $ref: '#/definitions/dto.TxResponse'
-            type: array
+            $ref: '#/definitions/dto.TxsResponse'
         "400":
           description: Bad Request
           schema:
@@ -2630,7 +2665,7 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/apperror.Response'
-      summary: Get transaction by account address
+      summary: Get transactions by account address
       tags:
       - Transaction
   /indexer/tx/v1/txs/count:

--- a/api/dto/tx.go
+++ b/api/dto/tx.go
@@ -99,8 +99,13 @@ type TxResponse struct {
 	Info      string  `json:"info"`
 }
 
-type TxsResponse struct {
+type TxsModelResponse struct {
 	Txs        []TxModel          `json:"txs"`
+	Pagination PaginationResponse `json:"pagination"`
+}
+
+type TxsResponse struct {
+	Txs        []TxResponse       `json:"txs"`
 	Pagination PaginationResponse `json:"pagination"`
 }
 

--- a/api/handlers/tx.go
+++ b/api/handlers/tx.go
@@ -38,7 +38,7 @@ func (h *TxHandler) GetTxCount(c *fiber.Ctx) error {
 }
 
 // GetTxsByAccountAddress godoc
-// @Summary  Get transaction by account address
+// @Summary  Get transactions by account address
 // @Description Retrieve transactions by account address
 // @Tags Transaction
 // @Produce json
@@ -47,7 +47,7 @@ func (h *TxHandler) GetTxCount(c *fiber.Ctx) error {
 // @Param pagination.limit query integer false "Limit for pagination" default(10)
 // @Param pagination.reverse query boolean false "Reverse order for pagination" default(false)
 // @Param pagination.count_total query boolean false "Count total number of transactions" default(false)
-// @Success 200 {array} dto.TxResponse "Transaction list"
+// @Success 200 {object} dto.TxsResponse "OK"
 // @Failure 400 {object} apperror.Response
 // @Failure 500 {object} apperror.Response
 // @Router /indexer/tx/v1/txs/by_account/{accountAddress} [get]
@@ -81,7 +81,7 @@ func (h *TxHandler) GetTxsByBlockHeight(c *fiber.Ctx) error {
 // @Accept json
 // @Produce json
 // @Param tx_hash path string true "Transaction hash"
-// @Success 200 {object} dto.TxResponse
+// @Success 200 {object} dto.TxByHashResponse "OK"
 // @Failure 400 {object} apperror.Response
 // @Failure 500 {object} apperror.Response
 // @Router /indexer/tx/v1/txs/{tx_hash} [get]
@@ -104,7 +104,7 @@ func (h *TxHandler) GetTxByHash(c *fiber.Ctx) error {
 // @Param pagination.limit query integer false "Limit for pagination" default(10)
 // @Param pagination.reverse query boolean false "Reverse order for pagination" default(false)
 // @Param pagination.count_total query boolean false "Count total number of transactions" default(false)
-// @Success 200 {object} dto.TxsResponse
+// @Success 200 {object} dto.TxsModelResponse "OK"
 // @Failure 400 {object} apperror.Response
 // @Failure 500 {object} apperror.Response
 // @Router /indexer/tx/v1/txs [get]

--- a/api/handlers/tx.go
+++ b/api/handlers/tx.go
@@ -6,6 +6,7 @@ import (
 	"github.com/initia-labs/core-indexer/api/apperror"
 	"github.com/initia-labs/core-indexer/api/dto"
 	"github.com/initia-labs/core-indexer/api/services"
+	"github.com/initia-labs/core-indexer/pkg/parser"
 )
 
 type TxHandler struct {
@@ -34,6 +35,43 @@ func (h *TxHandler) GetTxCount(c *fiber.Ctx) error {
 	}
 
 	return c.JSON(txCount)
+}
+
+// GetTxsByAccountAddress godoc
+// @Summary  Get transaction by account address
+// @Description Retrieve transactions by account address
+// @Tags Transaction
+// @Produce json
+// @Param accountAddress path string true "Account address"
+// @Param pagination.offset query integer false "Offset for pagination" default(0)
+// @Param pagination.limit query integer false "Limit for pagination" default(10)
+// @Param pagination.reverse query boolean false "Reverse order for pagination" default(false)
+// @Param pagination.count_total query boolean false "Count total number of transactions" default(false)
+// @Success 200 {array} dto.TxResponse "Transaction list"
+// @Failure 400 {object} apperror.Response
+// @Failure 500 {object} apperror.Response
+// @Router /indexer/tx/v1/txs/by_account/{accountAddress} [get]
+func (h *TxHandler) GetTxsByAccountAddress(c *fiber.Ctx) error {
+	pagination, err := dto.PaginationFromQuery(c)
+	if err != nil {
+		return apperror.HandleErrorResponse(c, err)
+	}
+
+	accountAddress, err := parser.AccAddressFromString(c.Params("accountAddress"))
+	if err != nil {
+		return apperror.HandleErrorResponse(c, err)
+	}
+
+	response, err := h.service.GetTxsByAccountAddress(*pagination, accountAddress.String())
+	if err != nil {
+		return apperror.HandleErrorResponse(c, err)
+	}
+
+	return c.JSON(response)
+}
+
+func (h *TxHandler) GetTxsByBlockHeight(c *fiber.Ctx) error {
+	return nil
 }
 
 // GetTxByHash godoc

--- a/api/repositories/repository.go
+++ b/api/repositories/repository.go
@@ -77,6 +77,7 @@ type TxRepositoryI interface {
 	GetTxByHash(hash string) (*dto.TxByHashResponse, error)
 	GetTxCount() (*int64, error)
 	GetTxs(pagination dto.PaginationQuery) ([]dto.TxModel, int64, error)
+	GetTxsByAccountAddress(pagnination dto.PaginationQuery, accountAddress string) ([]dto.TxModel, int64, error)
 }
 
 type BlockRepositoryI interface {

--- a/api/repositories/repository.go
+++ b/api/repositories/repository.go
@@ -77,7 +77,6 @@ type TxRepositoryI interface {
 	GetTxByHash(hash string) (*dto.TxByHashResponse, error)
 	GetTxCount() (*int64, error)
 	GetTxs(pagination dto.PaginationQuery) ([]dto.TxModel, int64, error)
-	GetTxsByAccountAddress(pagnination dto.PaginationQuery, accountAddress string) ([]dto.TxModel, int64, error)
 }
 
 type BlockRepositoryI interface {

--- a/api/repositories/tx.go
+++ b/api/repositories/tx.go
@@ -151,38 +151,3 @@ func (r *TxRepository) GetTxs(pagination dto.PaginationQuery) ([]dto.TxModel, in
 
 	return record, total, nil
 }
-
-// GetTxsByAccountAddress retrieves transactions by account address with pagination
-func (r *TxRepository) GetTxsByAccountAddress(pagination dto.PaginationQuery, accountAddress string) ([]dto.TxModel, int64, error) {
-	record := make([]dto.TxModel, 0)
-	total := int64(0)
-
-	if err := r.db.
-		Model(&db.Transaction{}).
-		Where("transactions.sender = ?", accountAddress).
-		Select("transactions.sender, transactions.hash, transactions.success, transactions.messages, transactions.is_send, transactions.is_ibc, transactions.is_opinit, blocks.height, blocks.timestamp").
-		Joins("LEFT JOIN blocks ON transactions.block_height = blocks.height").
-		Clauses(clause.OrderBy{
-			Columns: []clause.OrderByColumn{
-				{Column: clause.Column{Name: "transactions.block_height"}, Desc: pagination.Reverse},
-				{Column: clause.Column{Name: "transactions.block_index"}, Desc: pagination.Reverse},
-			},
-		}).
-		Limit(pagination.Limit).
-		Offset(pagination.Offset).
-		Find(&record).Error; err != nil {
-		logger.Get().Error().Err(err).Msg("Failed to query transactions")
-		return nil, 0, err
-	}
-
-	if pagination.CountTotal {
-		if err := r.db.Model(&db.Tracking{}).
-			Select("tx_count").
-			First(&total).Error; err != nil {
-			logger.Get().Error().Err(err).Msg("Failed to get transaction count")
-			return nil, 0, err
-		}
-	}
-
-	return record, total, nil
-}

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -16,7 +16,7 @@ func SetupRoutes(app *fiber.App, dbClient *gorm.DB, buckets []*blob.Bucket) {
 	SetupModuleRoutes(app, repos.ModuleRepository)
 	SetupNftRoutes(app, repos.NftRepository)
 	SetupProposalRoutes(app, repos.ProposalRepository)
-	SetupTxRoutes(app, repos.TxRepository)
+	SetupTxRoutes(app, repos.TxRepository, repos.AccountRepository)
 	SetupValidatorRoutes(app, repos.ValidatorRepository, repos.BlockRepository, repos.ProposalRepository)
 	SetupAccountRoutes(app, repos.AccountRepository)
 }

--- a/api/routes/tx.go
+++ b/api/routes/tx.go
@@ -9,9 +9,9 @@ import (
 )
 
 // SetupTxRoutes sets up the Tx routes
-func SetupTxRoutes(app *fiber.App, txRepo repositories.TxRepositoryI) {
+func SetupTxRoutes(app *fiber.App, txRepo repositories.TxRepositoryI, accountRepo repositories.AccountRepositoryI) {
 	// Initialize services
-	txService := services.NewTxService(txRepo)
+	txService := services.NewTxService(txRepo, accountRepo)
 
 	// Initialize handlers
 	txHandler := handlers.NewTxHandler(txService)

--- a/api/routes/tx.go
+++ b/api/routes/tx.go
@@ -24,4 +24,5 @@ func SetupTxRoutes(app *fiber.App, txRepo repositories.TxRepositoryI) {
 	txs.Get("/", txHandler.GetTxs)
 	txs.Get("/count", txHandler.GetTxCount)
 	txs.Get("/:tx_hash", txHandler.GetTxByHash)
+	txs.Get("/by_account/:accountAddress", txHandler.GetTxsByAccountAddress)
 }

--- a/api/services/tx.go
+++ b/api/services/tx.go
@@ -91,7 +91,7 @@ func (s *txService) GetTxsByAccountAddress(pagination dto.PaginationQuery, accou
 	}
 
 	for idx, tx := range txs {
-		txResponse, err := s.repo.GetTxByHash(tx.Hash)
+		txResponse, err := s.repo.GetTxByHash(fmt.Sprintf("%x", tx.Hash))
 		if err != nil {
 			return nil, err
 		}

--- a/api/services/tx.go
+++ b/api/services/tx.go
@@ -15,12 +15,14 @@ type TxService interface {
 }
 
 type txService struct {
-	repo repositories.TxRepositoryI
+	repo        repositories.TxRepositoryI
+	accountRepo repositories.AccountRepositoryI
 }
 
-func NewTxService(repo repositories.TxRepositoryI) TxService {
+func NewTxService(repo repositories.TxRepositoryI, accountRepo repositories.AccountRepositoryI) TxService {
 	return &txService{
-		repo: repo,
+		repo:        repo,
+		accountRepo: accountRepo,
 	}
 }
 
@@ -77,7 +79,7 @@ func (s *txService) GetTxs(pagination dto.PaginationQuery) (*dto.TxsModelRespons
 }
 
 func (s *txService) GetTxsByAccountAddress(pagination dto.PaginationQuery, accountAddress string) (*dto.TxsResponse, error) {
-	txs, total, err := s.repo.GetTxsByAccountAddress(pagination, accountAddress)
+	txs, total, err := s.accountRepo.GetAccountTxs(pagination, accountAddress, "", false, false, false, false, false, false, false, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added GET endpoint to retrieve transactions by account address with pagination and optional total count.

- Improvements
  - Faster, more resilient transaction fetching via batched lookups with caching, concurrency and retry/backoff.
  - Transaction list endpoint now provides two tailored response shapes: a compact model list and a full transaction-with-response list for account queries.

- Documentation
  - API docs updated to reflect the new endpoint, parameters and response shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->