### PR TITLE
fix: enhance error handling in GetBlock and GetBlockResults methods

### DIFF
--- a/pkg/cosmosrpc/errors.go
+++ b/pkg/cosmosrpc/errors.go
@@ -1,0 +1,5 @@
+package cosmosrpc
+
+import "errors"
+
+var ErrorZeroActiveClients = errors.New("zero active clients")

--- a/sweeper/sweeper/sweeper.go
+++ b/sweeper/sweeper/sweeper.go
@@ -236,19 +236,15 @@ func (s *Sweeper) GetBlockFromRPCAndProduce(parentCtx context.Context, height in
 
 func (s *Sweeper) GetBlock(ctx context.Context, height int64) *coretypes.ResultBlock {
 	retryCount := 0
-	hub := sentry.GetHubFromContext(ctx)
 	for {
 		block, err := s.rpcClient.Block(ctx, &height)
 		if err != nil {
 			retryCount++
 			if retryCount%10 == 0 {
-				if rebalanceErr := s.rpcClient.Rebalance(ctx); rebalanceErr != nil {
-					logger.Error().Msgf("Error rebalancing clients: %v", rebalanceErr)
-				}
-				sentry_integration.CaptureException(hub, err, sentry.LevelError)
+				s.RebalanceRPCs(ctx)
 			}
-			logger.Error().Msgf("RPC: Error getting block %d: %v\n", height, err)
 			time.Sleep(time.Second)
+			logger.Error().Msgf("RPC: Error getting block %d: %v\n", height, err)
 			continue
 		}
 		return block
@@ -257,22 +253,31 @@ func (s *Sweeper) GetBlock(ctx context.Context, height int64) *coretypes.ResultB
 
 func (s *Sweeper) GetBlockResults(ctx context.Context, height int64) *coretypes.ResultBlockResults {
 	retryCount := 0
-	hub := sentry.GetHubFromContext(ctx)
 	for {
 		blockResult, err := s.rpcClient.BlockResults(ctx, &height)
 		if err != nil {
 			retryCount++
 			if retryCount%10 == 0 {
-				if rebalanceErr := s.rpcClient.Rebalance(ctx); rebalanceErr != nil {
-					logger.Error().Msgf("Error rebalancing clients: %v", rebalanceErr)
-				}
-				sentry_integration.CaptureException(hub, err, sentry.LevelError)
+				s.RebalanceRPCs(ctx)
 			}
 			logger.Error().Msgf("RPC: Error getting block results %d: %v\n", height, err)
 			time.Sleep(time.Second)
 			continue
 		}
 		return blockResult
+	}
+}
+
+func (s *Sweeper) RebalanceRPCs(ctx context.Context) {
+	hub := sentry.GetHubFromContext(ctx)
+	err := s.rpcClient.Rebalance(ctx)
+	if err != nil {
+		logger.Error().Msgf("Error rebalancing clients: %v", err)
+		sentry_integration.CaptureException(hub, err, sentry.LevelError)
+	}
+	actives := s.rpcClient.GetActiveClients()
+	for _, active := range actives {
+		logger.Info().Msgf("Active client url: %s, latest height: %d", active.Client.GetIdentifier(), active.Height)
 	}
 }
 

--- a/sweeper/sweeper/sweeper.go
+++ b/sweeper/sweeper/sweeper.go
@@ -240,6 +240,7 @@ func (s *Sweeper) GetBlock(ctx context.Context, height int64) *coretypes.ResultB
 	for {
 		block, err := s.rpcClient.Block(ctx, &height)
 		if err != nil {
+			retryCount++
 			if retryCount%10 == 0 {
 				err := s.rpcClient.Rebalance(ctx)
 				if err != nil {
@@ -249,8 +250,6 @@ func (s *Sweeper) GetBlock(ctx context.Context, height int64) *coretypes.ResultB
 			}
 			logger.Error().Msgf("RPC: Error getting block %d: %v\n", height, err)
 			time.Sleep(time.Second)
-
-			retryCount++
 			continue
 		}
 		return block
@@ -263,6 +262,7 @@ func (s *Sweeper) GetBlockResults(ctx context.Context, height int64) *coretypes.
 	for {
 		blockResult, err := s.rpcClient.BlockResults(ctx, &height)
 		if err != nil {
+			retryCount++
 			if retryCount%10 == 0 {
 				err := s.rpcClient.Rebalance(ctx)
 				if err != nil {
@@ -272,8 +272,6 @@ func (s *Sweeper) GetBlockResults(ctx context.Context, height int64) *coretypes.
 			}
 			logger.Error().Msgf("RPC: Error getting block results %d: %v\n", height, err)
 			time.Sleep(time.Second)
-
-			retryCount++
 			continue
 		}
 		return blockResult

--- a/sweeper/sweeper/sweeper.go
+++ b/sweeper/sweeper/sweeper.go
@@ -230,18 +230,18 @@ func (s *Sweeper) GetBlockFromRPCAndProduce(parentCtx context.Context, height in
 
 	block, err := s.GetBlock(ctx, height)
 	if err != nil {
-		logger.Fatal().Msgf("RPC: Error getting block %d: %v\n", height, err)
+		logger.Error().Msgf("RPC: Error getting block %d: %v\n", height, err)
 		return err
 	}
 	blockResult, err := s.GetBlockResults(ctx, height)
 	if err != nil {
-		logger.Fatal().Msgf("RPC: Error getting block results %d: %v\n", height, err)
+		logger.Error().Msgf("RPC: Error getting block results %d: %v\n", height, err)
 		return err
 	}
 
 	err = s.MakeAndSendBlockResultMsg(ctx, block, blockResult)
 	if err != nil {
-		logger.Fatal().Msgf("Kafka: Error producing message at height: %d. Error: %v\n", height, err)
+		logger.Error().Msgf("Kafka: Error producing message at height: %d. Error: %v\n", height, err)
 		return err
 	}
 	return nil

--- a/sweeper/sweeper/sweeper.go
+++ b/sweeper/sweeper/sweeper.go
@@ -239,9 +239,12 @@ func (s *Sweeper) GetBlock(ctx context.Context, height int64) *coretypes.ResultB
 	hub := sentry.GetHubFromContext(ctx)
 	for {
 		block, err := s.rpcClient.Block(ctx, &height)
-		// TODO: make a retry count function
 		if err != nil {
-			if retryCount == 3 {
+			if retryCount%10 == 0 {
+				err := s.rpcClient.Rebalance(ctx)
+				if err != nil {
+					logger.Error().Msgf("Error rebalancing clients: %v", err)
+				}
 				sentry_integration.CaptureException(hub, err, sentry.LevelError)
 			}
 			logger.Error().Msgf("RPC: Error getting block %d: %v\n", height, err)
@@ -260,7 +263,11 @@ func (s *Sweeper) GetBlockResults(ctx context.Context, height int64) *coretypes.
 	for {
 		blockResult, err := s.rpcClient.BlockResults(ctx, &height)
 		if err != nil {
-			if retryCount == 3 {
+			if retryCount%10 == 0 {
+				err := s.rpcClient.Rebalance(ctx)
+				if err != nil {
+					logger.Error().Msgf("Error rebalancing clients: %v", err)
+				}
 				sentry_integration.CaptureException(hub, err, sentry.LevelError)
 			}
 			logger.Error().Msgf("RPC: Error getting block results %d: %v\n", height, err)

--- a/sweeper/sweeper/sweeper.go
+++ b/sweeper/sweeper/sweeper.go
@@ -242,9 +242,8 @@ func (s *Sweeper) GetBlock(ctx context.Context, height int64) *coretypes.ResultB
 		if err != nil {
 			retryCount++
 			if retryCount%10 == 0 {
-				err := s.rpcClient.Rebalance(ctx)
-				if err != nil {
-					logger.Error().Msgf("Error rebalancing clients: %v", err)
+				if rebalanceErr := s.rpcClient.Rebalance(ctx); rebalanceErr != nil {
+					logger.Error().Msgf("Error rebalancing clients: %v", rebalanceErr)
 				}
 				sentry_integration.CaptureException(hub, err, sentry.LevelError)
 			}
@@ -264,9 +263,8 @@ func (s *Sweeper) GetBlockResults(ctx context.Context, height int64) *coretypes.
 		if err != nil {
 			retryCount++
 			if retryCount%10 == 0 {
-				err := s.rpcClient.Rebalance(ctx)
-				if err != nil {
-					logger.Error().Msgf("Error rebalancing clients: %v", err)
+				if rebalanceErr := s.rpcClient.Rebalance(ctx); rebalanceErr != nil {
+					logger.Error().Msgf("Error rebalancing clients: %v", rebalanceErr)
 				}
 				sentry_integration.CaptureException(hub, err, sentry.LevelError)
 			}

--- a/sweeper/sweeper/sweeper.go
+++ b/sweeper/sweeper/sweeper.go
@@ -214,71 +214,85 @@ func (s *Sweeper) StartSweeping(signalCtx context.Context) {
 				scope.SetTag("height", fmt.Sprint(height))
 			})
 			ctx := sentry.SetHubOnContext(context.Background(), localHub)
-			s.GetBlockFromRPCAndProduce(ctx, height)
+			err := s.GetBlockFromRPCAndProduce(ctx, height)
+			if err != nil {
+				panic(err)
+			}
 		}
 	}
 }
 
-func (s *Sweeper) GetBlockFromRPCAndProduce(parentCtx context.Context, height int64) {
+func (s *Sweeper) GetBlockFromRPCAndProduce(parentCtx context.Context, height int64) error {
 	logger.Info().Msgf("RPC: Getting data from block_results: %d", height)
 
 	transaction, ctx := sentry_integration.StartSentryTransaction(parentCtx, "Sweep", "Sweep block_results from RPC and produce to Kafka")
 	defer transaction.Finish()
 
-	block := s.GetBlock(ctx, height)
-	blockResult := s.GetBlockResults(ctx, height)
+	block, err := s.GetBlock(ctx, height)
+	if err != nil {
+		logger.Fatal().Msgf("RPC: Error getting block %d: %v\n", height, err)
+		return err
+	}
+	blockResult, err := s.GetBlockResults(ctx, height)
+	if err != nil {
+		logger.Fatal().Msgf("RPC: Error getting block results %d: %v\n", height, err)
+		return err
+	}
 
-	err := s.MakeAndSendBlockResultMsg(ctx, block, blockResult)
+	err = s.MakeAndSendBlockResultMsg(ctx, block, blockResult)
 	if err != nil {
 		logger.Fatal().Msgf("Kafka: Error producing message at height: %d. Error: %v\n", height, err)
+		return err
 	}
+	return nil
 }
 
-func (s *Sweeper) GetBlock(ctx context.Context, height int64) *coretypes.ResultBlock {
+func (s *Sweeper) GetBlock(ctx context.Context, height int64) (*coretypes.ResultBlock, error) {
 	retryCount := 0
 	for {
 		block, err := s.rpcClient.Block(ctx, &height)
 		if err != nil {
 			retryCount++
 			if retryCount%10 == 0 {
-				s.RebalanceRPCs(ctx)
+				err := s.RebalanceRPCs(ctx)
+				if errors.Is(err, cosmosrpc.ErrorZeroActiveClients) {
+					return nil, err
+				}
 			}
 			time.Sleep(time.Second)
 			logger.Error().Msgf("RPC: Error getting block %d: %v\n", height, err)
 			continue
 		}
-		return block
+		return block, nil
 	}
 }
 
-func (s *Sweeper) GetBlockResults(ctx context.Context, height int64) *coretypes.ResultBlockResults {
+func (s *Sweeper) GetBlockResults(ctx context.Context, height int64) (*coretypes.ResultBlockResults, error) {
 	retryCount := 0
 	for {
 		blockResult, err := s.rpcClient.BlockResults(ctx, &height)
 		if err != nil {
 			retryCount++
 			if retryCount%10 == 0 {
-				s.RebalanceRPCs(ctx)
+				err := s.RebalanceRPCs(ctx)
+				if errors.Is(err, cosmosrpc.ErrorZeroActiveClients) {
+					return nil, err
+				}
 			}
 			logger.Error().Msgf("RPC: Error getting block results %d: %v\n", height, err)
 			time.Sleep(time.Second)
 			continue
 		}
-		return blockResult
+		return blockResult, nil
 	}
 }
 
-func (s *Sweeper) RebalanceRPCs(ctx context.Context) {
-	hub := sentry.GetHubFromContext(ctx)
+func (s *Sweeper) RebalanceRPCs(ctx context.Context) error {
 	err := s.rpcClient.Rebalance(ctx)
 	if err != nil {
-		logger.Error().Msgf("Error rebalancing clients: %v", err)
-		sentry_integration.CaptureException(hub, err, sentry.LevelError)
+		return err
 	}
-	actives := s.rpcClient.GetActiveClients()
-	for _, active := range actives {
-		logger.Info().Msgf("Active client url: %s, latest height: %d", active.Client.GetIdentifier(), active.Height)
-	}
+	return nil
 }
 
 func (s *Sweeper) MakeAndSendBlockResultMsg(ctx context.Context, block *coretypes.ResultBlock, blockResult *coretypes.ResultBlockResults) error {


### PR DESCRIPTION
- Updated the retry logic in the GetBlock and GetBlockResults methods to trigger a rebalance of RPC clients every 10 retries, improving error handling and client management.
- Added logging for errors encountered during the rebalance process to aid in debugging and monitoring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * RPC failures are now surfaced to the caller instead of being silently retried, improving error visibility.
  * Retry logic now triggers a periodic client rebalance during extended retry cycles (every 10 errors).
  * Sweeping will stop and report an unrecoverable client-zero condition immediately.
  * Improved error reporting and logging to aid troubleshooting during RPC/retry failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->