### PR TITLE
feat: implement custom memory-based LRU cache, add runtime debug metr…

### DIFF
--- a/api/config/config.go
+++ b/api/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -10,13 +11,19 @@ import (
 type Config struct {
 	// Server configuration
 	Server struct {
-		Port        string
-		ReadTimeout time.Duration
+		Port         string
+		ReadTimeout  time.Duration
+		WriteTimeout time.Duration
+		IdleTimeout  time.Duration
 	}
 
 	// Database configuration
 	Database struct {
 		ConnectionString string
+		MaxOpenConns     int
+		MaxIdleConns     int
+		ConnMaxLifetime  time.Duration
+		ConnMaxIdleTime  time.Duration
 	}
 
 	// Repository configuration
@@ -32,7 +39,14 @@ type Config struct {
 
 	// Storage
 	Storage struct {
-		Buckets []string
+		Buckets              []string
+		TxResponseCacheBytes int64
+		TxMaxWorkers         int
+	}
+
+	// Observability
+	Observability struct {
+		RuntimeMetricsEnabled bool
 	}
 }
 
@@ -43,9 +57,15 @@ func New() *Config {
 	// Server configuration
 	config.Server.Port = getEnv("PORT", "8080")
 	config.Server.ReadTimeout = getDurationEnv("SERVER_READ_TIMEOUT", 15*time.Second)
+	config.Server.WriteTimeout = getDurationEnv("SERVER_WRITE_TIMEOUT", 30*time.Second)
+	config.Server.IdleTimeout = getDurationEnv("SERVER_IDLE_TIMEOUT", 60*time.Second)
 
 	// Database configuration
 	config.Database.ConnectionString = getEnv("DB_CONNECTION_STRING_RO", "postgres://postgres:postgres@localhost:5432/core_indexer?sslmode=disable")
+	config.Database.MaxOpenConns = getIntEnv("DB_MAX_OPEN_CONNS", 10)
+	config.Database.MaxIdleConns = getIntEnv("DB_MAX_IDLE_CONNS", 5)
+	config.Database.ConnMaxLifetime = getDurationEnv("DB_CONN_MAX_LIFETIME", 30*time.Minute)
+	config.Database.ConnMaxIdleTime = getDurationEnv("DB_CONN_MAX_IDLE_TIME", 5*time.Minute)
 
 	// Repository configuration
 	config.Repository.CountQueryTimeout = getDurationEnv("REPOSITORY_COUNT_QUERY_TIMEOUT", 5*time.Second)
@@ -58,6 +78,11 @@ func New() *Config {
 
 	// GCS Buckets
 	config.Storage.Buckets = strings.Split(getEnv("BUCKETS", ""), ",")
+	config.Storage.TxResponseCacheBytes = getBytesEnv("TX_RESPONSE_CACHE_BYTES", 64*1024*1024)
+	config.Storage.TxMaxWorkers = getIntEnv("TX_RESPONSE_MAX_WORKERS", 10)
+
+	// Observability
+	config.Observability.RuntimeMetricsEnabled = getBoolEnv("ENABLE_RUNTIME_METRICS", false)
 
 	return config
 }
@@ -82,4 +107,69 @@ func getDurationEnv(key string, defaultValue time.Duration) time.Duration {
 		return defaultValue
 	}
 	return duration
+}
+
+// getIntEnv gets an integer environment variable or returns a default value.
+func getIntEnv(key string, defaultValue int) int {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return defaultValue
+	}
+	return parsed
+}
+
+// getBoolEnv gets a boolean environment variable or returns a default value.
+func getBoolEnv(key string, defaultValue bool) bool {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return defaultValue
+	}
+	return parsed
+}
+
+// getBytesEnv parses byte values with optional KiB/MiB/GiB or KB/MB/GB suffixes.
+func getBytesEnv(key string, defaultValue int64) int64 {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return defaultValue
+	}
+
+	unit := int64(1)
+	number := value
+	lower := strings.ToLower(value)
+
+	units := []struct {
+		suffix     string
+		multiplier int64
+	}{
+		{suffix: "gib", multiplier: 1024 * 1024 * 1024},
+		{suffix: "gb", multiplier: 1000 * 1000 * 1000},
+		{suffix: "mib", multiplier: 1024 * 1024},
+		{suffix: "mb", multiplier: 1000 * 1000},
+		{suffix: "kib", multiplier: 1024},
+		{suffix: "kb", multiplier: 1000},
+		{suffix: "b", multiplier: 1},
+	}
+
+	for _, candidate := range units {
+		if strings.HasSuffix(lower, candidate.suffix) {
+			unit = candidate.multiplier
+			number = strings.TrimSpace(value[:len(value)-len(candidate.suffix)])
+			break
+		}
+	}
+
+	parsed, err := strconv.ParseInt(number, 10, 64)
+	if err != nil || parsed < 0 {
+		return defaultValue
+	}
+	return parsed * unit
 }

--- a/api/dto/tx.go
+++ b/api/dto/tx.go
@@ -78,8 +78,9 @@ type Tx struct {
 
 // RestTxResponse represents the complete transaction response
 type TxByHashResponse struct {
-	Tx         Tx         `json:"tx"`
-	TxResponse TxResponse `json:"tx_response"`
+	Tx             Tx         `json:"tx"`
+	TxResponse     TxResponse `json:"tx_response"`
+	CacheSizeBytes int64      `json:"-"`
 }
 
 // TxResponse represents the response structure for a transaction

--- a/api/main.go
+++ b/api/main.go
@@ -72,6 +72,15 @@ func initDatabase(cfg *config.Config) *gorm.DB {
 		log.Fatal().Err(err).Msg("Failed to connect to database")
 	}
 
+	sqlDB, err := dbClient.DB()
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to get database pool")
+	}
+	sqlDB.SetMaxOpenConns(cfg.Database.MaxOpenConns)
+	sqlDB.SetMaxIdleConns(cfg.Database.MaxIdleConns)
+	sqlDB.SetConnMaxLifetime(cfg.Database.ConnMaxLifetime)
+	sqlDB.SetConnMaxIdleTime(cfg.Database.ConnMaxIdleTime)
+
 	// Test database connection
 	if err := db.Ping(context.Background(), dbClient); err != nil {
 		log.Fatal().Err(err).Msg("Failed to ping database")
@@ -152,8 +161,10 @@ func main() {
 
 	// Create Fiber app
 	app := fiber.New(fiber.Config{
-		AppName:     "Core Indexer API",
-		ReadTimeout: cfg.Server.ReadTimeout,
+		AppName:      "Core Indexer API",
+		ReadTimeout:  cfg.Server.ReadTimeout,
+		WriteTimeout: cfg.Server.WriteTimeout,
+		IdleTimeout:  cfg.Server.IdleTimeout,
 	})
 
 	// Middleware
@@ -184,6 +195,10 @@ func main() {
 			"status": "OK",
 		})
 	})
+
+	if cfg.Observability.RuntimeMetricsEnabled {
+		routes.SetupRuntimeMetricsRoute(app, dbClient)
+	}
 
 	// Setup routes
 	routes.SetupRoutes(app, dbClient, buckets, cfg)

--- a/api/repositories/tx.go
+++ b/api/repositories/tx.go
@@ -121,6 +121,8 @@ func (r *TxRepository) GetTxByHash(ctx context.Context, hash string) (*dto.TxByH
 		txResponse.TxResponse = *flatResponse
 	}
 
+	txResponse.CacheSizeBytes = int64(len(data))
+
 	return txResponse, nil
 }
 

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -17,7 +17,7 @@ func SetupRoutes(app *fiber.App, dbClient *gorm.DB, buckets []*blob.Bucket, conf
 	SetupModuleRoutes(app, repos.ModuleRepository)
 	SetupNftRoutes(app, repos.NftRepository)
 	SetupProposalRoutes(app, repos.ProposalRepository)
-	SetupTxRoutes(app, repos.TxRepository, repos.AccountRepository)
+	SetupTxRoutes(app, repos.TxRepository, repos.AccountRepository, config)
 	SetupValidatorRoutes(app, repos.ValidatorRepository, repos.BlockRepository, repos.ProposalRepository)
 	SetupAccountRoutes(app, repos.AccountRepository)
 }

--- a/api/routes/runtime_metrics.go
+++ b/api/routes/runtime_metrics.go
@@ -42,7 +42,6 @@ func SetupRuntimeMetricsRoute(app *fiber.App, dbClient *gorm.DB) {
 					"mcache_in_use_bytes":     mem.MCacheInuse,
 					"mcache_sys_bytes":        mem.MCacheSys,
 					"buck_hash_sys_bytes":     mem.BuckHashSys,
-					"gc_metadata_sys_bytes":   mem.GCSys,
 					"other_runtime_sys_bytes": mem.OtherSys,
 				},
 			},

--- a/api/routes/runtime_metrics.go
+++ b/api/routes/runtime_metrics.go
@@ -1,0 +1,68 @@
+package routes
+
+import (
+	"runtime"
+
+	"github.com/gofiber/fiber/v2"
+	"gorm.io/gorm"
+)
+
+// SetupRuntimeMetricsRoute exposes a small runtime snapshot for operational debugging.
+func SetupRuntimeMetricsRoute(app *fiber.App, dbClient *gorm.DB) {
+	app.Get("/indexer/debug/runtime", func(c *fiber.Ctx) error {
+		var mem runtime.MemStats
+		runtime.ReadMemStats(&mem)
+
+		response := fiber.Map{
+			"go": fiber.Map{
+				"goroutines": runtime.NumGoroutine(),
+				"memory": fiber.Map{
+					"alloc_bytes":         mem.Alloc,
+					"total_alloc_bytes":   mem.TotalAlloc,
+					"sys_bytes":           mem.Sys,
+					"heap_alloc_bytes":    mem.HeapAlloc,
+					"heap_sys_bytes":      mem.HeapSys,
+					"heap_idle_bytes":     mem.HeapIdle,
+					"heap_in_use_bytes":   mem.HeapInuse,
+					"heap_released_bytes": mem.HeapReleased,
+					"heap_objects":        mem.HeapObjects,
+					"next_gc_bytes":       mem.NextGC,
+				},
+				"gc": fiber.Map{
+					"count":                   mem.NumGC,
+					"pause_total_ns":          mem.PauseTotalNs,
+					"last_gc_unix_nano":       mem.LastGC,
+					"gc_cpu_fraction":         mem.GCCPUFraction,
+					"forced_gc_count":         mem.NumForcedGC,
+					"gc_sys_bytes":            mem.GCSys,
+					"stack_in_use_bytes":      mem.StackInuse,
+					"stack_sys_bytes":         mem.StackSys,
+					"mspan_in_use_bytes":      mem.MSpanInuse,
+					"mspan_sys_bytes":         mem.MSpanSys,
+					"mcache_in_use_bytes":     mem.MCacheInuse,
+					"mcache_sys_bytes":        mem.MCacheSys,
+					"buck_hash_sys_bytes":     mem.BuckHashSys,
+					"gc_metadata_sys_bytes":   mem.GCSys,
+					"other_runtime_sys_bytes": mem.OtherSys,
+				},
+			},
+		}
+
+		if sqlDB, err := dbClient.DB(); err == nil {
+			stats := sqlDB.Stats()
+			response["database"] = fiber.Map{
+				"max_open_connections": stats.MaxOpenConnections,
+				"open_connections":     stats.OpenConnections,
+				"in_use":               stats.InUse,
+				"idle":                 stats.Idle,
+				"wait_count":           stats.WaitCount,
+				"wait_duration_ns":     stats.WaitDuration.Nanoseconds(),
+				"max_idle_closed":      stats.MaxIdleClosed,
+				"max_idle_time_closed": stats.MaxIdleTimeClosed,
+				"max_lifetime_closed":  stats.MaxLifetimeClosed,
+			}
+		}
+
+		return c.JSON(response)
+	})
+}

--- a/api/routes/tx.go
+++ b/api/routes/tx.go
@@ -3,15 +3,16 @@ package routes
 import (
 	"github.com/gofiber/fiber/v2"
 
+	"github.com/initia-labs/core-indexer/api/config"
 	"github.com/initia-labs/core-indexer/api/handlers"
 	"github.com/initia-labs/core-indexer/api/repositories"
 	"github.com/initia-labs/core-indexer/api/services"
 )
 
 // SetupTxRoutes sets up the Tx routes
-func SetupTxRoutes(app *fiber.App, txRepo repositories.TxRepositoryI, accountRepo repositories.AccountRepositoryI) {
+func SetupTxRoutes(app *fiber.App, txRepo repositories.TxRepositoryI, accountRepo repositories.AccountRepositoryI, cfg *config.Config) {
 	// Initialize services
-	txService := services.NewTxService(txRepo, accountRepo)
+	txService := services.NewTxService(txRepo, accountRepo, cfg)
 
 	// Initialize handlers
 	txHandler := handlers.NewTxHandler(txService)

--- a/api/services/gcs.go
+++ b/api/services/gcs.go
@@ -252,7 +252,13 @@ func (g *GCSManager) QueryTxs(ctx context.Context, hashes []string) ([]*dto.TxBy
 	}()
 
 	for i := 0; i < len(uncachedHashes); i++ {
-		result := <-resultChan
+		var result TaskResult
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case result = <-resultChan:
+		}
+
 		if result.Err != nil {
 			cancel()
 			return nil, result.Err

--- a/api/services/gcs.go
+++ b/api/services/gcs.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/initia-labs/core-indexer/api/dto"
 	"github.com/initia-labs/core-indexer/api/repositories"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -17,19 +18,6 @@ const (
 	MaxRetryDelay = 10 * time.Second
 	CacheBytes    = 64 * 1024 * 1024
 )
-
-// Task represents a work item for the worker pool
-type Task struct {
-	Index int
-	Hash  string
-}
-
-// TaskResult represents the result of processing a task
-type TaskResult struct {
-	Index int
-	Tx    *dto.TxByHashResponse
-	Err   error
-}
 
 type txCacheEntry struct {
 	hash string
@@ -194,11 +182,7 @@ func (g *GCSManager) QueryTxs(ctx context.Context, hashes []string) ([]*dto.TxBy
 		return []*dto.TxByHashResponse{}, nil
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	txs := make([]*dto.TxByHashResponse, len(hashes))
-	resultChan := make(chan TaskResult, len(hashes))
 
 	// Check cache first and collect uncached hashes
 	uncachedHashes := make([]int, 0)
@@ -210,60 +194,41 @@ func (g *GCSManager) QueryTxs(ctx context.Context, hashes []string) ([]*dto.TxBy
 		}
 	}
 
-	workerCount := min(g.MaxWorkers, len(uncachedHashes))
-	taskChan := make(chan int)
-
-	for range workerCount {
-		go func() {
-			for index := range taskChan {
-				hash := hashes[index]
-
-				var tx *dto.TxByHashResponse
-				var err error
-
-				err = g.retryWithBackoff(ctx, func() error {
-					tx, err = g.repo.GetTxByHash(ctx, hash)
-					return err
-				})
-
-				// Cache successful results
-				if err == nil && tx != nil {
-					g.cache.Add(hash, tx)
-				}
-
-				resultChan <- TaskResult{
-					Index: index,
-					Tx:    tx,
-					Err:   err,
-				}
-			}
-		}()
+	if len(uncachedHashes) == 0 {
+		return txs, nil
 	}
 
-	go func() {
-		defer close(taskChan)
-		for _, idx := range uncachedHashes {
-			select {
-			case <-ctx.Done():
-				return
-			case taskChan <- idx:
+	workerCount := min(g.MaxWorkers, len(uncachedHashes))
+	group, ctx := errgroup.WithContext(ctx)
+	group.SetLimit(workerCount)
+
+	for _, index := range uncachedHashes {
+		group.Go(func() error {
+			hash := hashes[index]
+
+			var tx *dto.TxByHashResponse
+			var err error
+
+			err = g.retryWithBackoff(ctx, func() error {
+				tx, err = g.repo.GetTxByHash(ctx, hash)
+				return err
+			})
+			if err != nil {
+				return err
 			}
-		}
-	}()
 
-	for i := 0; i < len(uncachedHashes); i++ {
-		var result TaskResult
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case result = <-resultChan:
-		}
+			// Cache successful results
+			if tx != nil {
+				g.cache.Add(hash, tx)
+			}
 
-		if result.Err != nil {
-			cancel()
-			return nil, result.Err
-		}
-		txs[result.Index] = result.Tx
+			txs[index] = tx
+			return nil
+		})
+	}
+
+	if err := group.Wait(); err != nil {
+		return nil, err
 	}
 
 	return txs, nil

--- a/api/services/gcs.go
+++ b/api/services/gcs.go
@@ -213,7 +213,7 @@ func (g *GCSManager) QueryTxs(ctx context.Context, hashes []string) ([]*dto.TxBy
 	workerCount := min(g.MaxWorkers, len(uncachedHashes))
 	taskChan := make(chan int)
 
-	for worker := 0; worker < workerCount; worker++ {
+	for range workerCount {
 		go func() {
 			for index := range taskChan {
 				hash := hashes[index]

--- a/api/services/gcs.go
+++ b/api/services/gcs.go
@@ -3,7 +3,6 @@ package services
 import (
 	"container/list"
 	"context"
-	"encoding/json"
 	"sync"
 	"time"
 
@@ -81,7 +80,7 @@ func (c *txResponseCache) Add(hash string, tx *dto.TxByHashResponse) {
 		return
 	}
 
-	size := estimateTxResponseSize(tx)
+	size := tx.CacheSizeBytes
 	if size <= 0 || size > c.maxBytes {
 		c.Remove(hash)
 		return
@@ -132,14 +131,6 @@ func (c *txResponseCache) removeElement(element *list.Element) {
 	delete(c.items, entry.hash)
 	c.used -= entry.size
 	c.order.Remove(element)
-}
-
-func estimateTxResponseSize(tx *dto.TxByHashResponse) int64 {
-	data, err := json.Marshal(tx)
-	if err != nil {
-		return 0
-	}
-	return int64(len(data))
 }
 
 type GCSManager struct {

--- a/api/services/gcs.go
+++ b/api/services/gcs.go
@@ -1,10 +1,12 @@
 package services
 
 import (
+	"container/list"
 	"context"
+	"encoding/json"
+	"sync"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/initia-labs/core-indexer/api/dto"
 	"github.com/initia-labs/core-indexer/api/repositories"
 )
@@ -14,7 +16,7 @@ const (
 	MaxRetries    = 3
 	RetryDelay    = time.Second
 	MaxRetryDelay = 10 * time.Second
-	CacheSize     = 10000
+	CacheBytes    = 64 * 1024 * 1024
 )
 
 // Task represents a work item for the worker pool
@@ -30,24 +32,141 @@ type TaskResult struct {
 	Err   error
 }
 
+type txCacheEntry struct {
+	hash string
+	tx   *dto.TxByHashResponse
+	size int64
+}
+
+type txResponseCache struct {
+	mu       sync.Mutex
+	maxBytes int64
+	used     int64
+	items    map[string]*list.Element
+	order    *list.List
+}
+
+func newTxResponseCache(maxBytes int64) *txResponseCache {
+	if maxBytes <= 0 {
+		return nil
+	}
+
+	return &txResponseCache{
+		maxBytes: maxBytes,
+		items:    make(map[string]*list.Element),
+		order:    list.New(),
+	}
+}
+
+func (c *txResponseCache) Get(hash string) (*dto.TxByHashResponse, bool) {
+	if c == nil {
+		return nil, false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	element, exists := c.items[hash]
+	if !exists {
+		return nil, false
+	}
+
+	c.order.MoveToFront(element)
+	entry := element.Value.(*txCacheEntry)
+	return entry.tx, true
+}
+
+func (c *txResponseCache) Add(hash string, tx *dto.TxByHashResponse) {
+	if c == nil || tx == nil {
+		return
+	}
+
+	size := estimateTxResponseSize(tx)
+	if size <= 0 || size > c.maxBytes {
+		c.Remove(hash)
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if element, exists := c.items[hash]; exists {
+		entry := element.Value.(*txCacheEntry)
+		c.used += size - entry.size
+		entry.tx = tx
+		entry.size = size
+		c.order.MoveToFront(element)
+	} else {
+		entry := &txCacheEntry{hash: hash, tx: tx, size: size}
+		c.items[hash] = c.order.PushFront(entry)
+		c.used += size
+	}
+
+	for c.used > c.maxBytes {
+		c.removeOldest()
+	}
+}
+
+func (c *txResponseCache) Remove(hash string) {
+	if c == nil {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if element, exists := c.items[hash]; exists {
+		c.removeElement(element)
+	}
+}
+
+func (c *txResponseCache) removeOldest() {
+	element := c.order.Back()
+	if element != nil {
+		c.removeElement(element)
+	}
+}
+
+func (c *txResponseCache) removeElement(element *list.Element) {
+	entry := element.Value.(*txCacheEntry)
+	delete(c.items, entry.hash)
+	c.used -= entry.size
+	c.order.Remove(element)
+}
+
+func estimateTxResponseSize(tx *dto.TxByHashResponse) int64 {
+	data, err := json.Marshal(tx)
+	if err != nil {
+		return 0
+	}
+	return int64(len(data))
+}
+
 type GCSManager struct {
 	MaxWorkers    int
 	MaxRetries    int
 	RetryDelay    time.Duration
 	MaxRetryDelay time.Duration
 	repo          repositories.TxRepositoryI
-	cache         *lru.Cache[string, *dto.TxByHashResponse]
+	cache         *txResponseCache
 }
 
 func NewGCSManager(repo repositories.TxRepositoryI) GCSManager {
-	cache, _ := lru.New[string, *dto.TxByHashResponse](CacheSize)
+	return NewGCSManagerWithConfig(repo, CacheBytes, MaxWorkers)
+}
+
+func NewGCSManagerWithConfig(repo repositories.TxRepositoryI, cacheBytes int64, maxWorkers int) GCSManager {
+	if maxWorkers < 1 {
+		maxWorkers = 1
+	}
+
 	return GCSManager{
 		repo:          repo,
-		MaxWorkers:    MaxWorkers,
+		MaxWorkers:    maxWorkers,
 		MaxRetries:    MaxRetries,
 		RetryDelay:    RetryDelay,
 		MaxRetryDelay: MaxRetryDelay,
-		cache:         cache,
+		cache:         newTxResponseCache(cacheBytes),
 	}
 }
 
@@ -84,6 +203,9 @@ func (g *GCSManager) QueryTxs(ctx context.Context, hashes []string) ([]*dto.TxBy
 		return []*dto.TxByHashResponse{}, nil
 	}
 
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	txs := make([]*dto.TxByHashResponse, len(hashes))
 	resultChan := make(chan TaskResult, len(hashes))
 
@@ -97,42 +219,51 @@ func (g *GCSManager) QueryTxs(ctx context.Context, hashes []string) ([]*dto.TxBy
 		}
 	}
 
-	// Create semaphore to limit concurrent goroutines
-	semaphore := make(chan struct{}, g.MaxWorkers)
+	workerCount := min(g.MaxWorkers, len(uncachedHashes))
+	taskChan := make(chan int)
 
-	// Launch goroutines only for uncached hashes with semaphore control
-	for _, idx := range uncachedHashes {
-		h := hashes[idx]
-		go func(index int, hash string) {
-			// Acquire semaphore
-			semaphore <- struct{}{}
-			defer func() { <-semaphore }() // Release semaphore when done
+	for worker := 0; worker < workerCount; worker++ {
+		go func() {
+			for index := range taskChan {
+				hash := hashes[index]
 
-			var tx *dto.TxByHashResponse
-			var err error
+				var tx *dto.TxByHashResponse
+				var err error
 
-			err = g.retryWithBackoff(ctx, func() error {
-				tx, err = g.repo.GetTxByHash(ctx, hash)
-				return err
-			})
+				err = g.retryWithBackoff(ctx, func() error {
+					tx, err = g.repo.GetTxByHash(ctx, hash)
+					return err
+				})
 
-			// Cache successful results
-			if err == nil && tx != nil {
-				g.cache.Add(hash, tx)
+				// Cache successful results
+				if err == nil && tx != nil {
+					g.cache.Add(hash, tx)
+				}
+
+				resultChan <- TaskResult{
+					Index: index,
+					Tx:    tx,
+					Err:   err,
+				}
 			}
-
-			resultChan <- TaskResult{
-				Index: index,
-				Tx:    tx,
-				Err:   err,
-			}
-		}(idx, h)
+		}()
 	}
 
-	// Collect results for uncached hashes
+	go func() {
+		defer close(taskChan)
+		for _, idx := range uncachedHashes {
+			select {
+			case <-ctx.Done():
+				return
+			case taskChan <- idx:
+			}
+		}
+	}()
+
 	for i := 0; i < len(uncachedHashes); i++ {
 		result := <-resultChan
 		if result.Err != nil {
+			cancel()
 			return nil, result.Err
 		}
 		txs[result.Index] = result.Tx

--- a/api/services/tx.go
+++ b/api/services/tx.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/initia-labs/core-indexer/api/config"
 	"github.com/initia-labs/core-indexer/api/dto"
 	"github.com/initia-labs/core-indexer/api/repositories"
 )
@@ -21,11 +22,11 @@ type txService struct {
 	gcsManager  GCSManager
 }
 
-func NewTxService(txRepo repositories.TxRepositoryI, accountRepo repositories.AccountRepositoryI) TxService {
+func NewTxService(txRepo repositories.TxRepositoryI, accountRepo repositories.AccountRepositoryI, cfg *config.Config) TxService {
 	return &txService{
 		txRepo:      txRepo,
 		accountRepo: accountRepo,
-		gcsManager:  NewGCSManager(txRepo),
+		gcsManager:  NewGCSManagerWithConfig(txRepo, cfg.Storage.TxResponseCacheBytes, cfg.Storage.TxMaxWorkers),
 	}
 }
 

--- a/charts/api/values.yaml
+++ b/charts/api/values.yaml
@@ -11,7 +11,17 @@ strategy:
 
 # List of environment variables
 env:
-  {}
+  GOMEMLIMIT: "384MiB"
+  GOGC: "100"
+  DB_MAX_OPEN_CONNS: "10"
+  DB_MAX_IDLE_CONNS: "5"
+  DB_CONN_MAX_LIFETIME: "30m"
+  DB_CONN_MAX_IDLE_TIME: "5m"
+  SERVER_WRITE_TIMEOUT: "30s"
+  SERVER_IDLE_TIMEOUT: "60s"
+  TX_RESPONSE_CACHE_BYTES: "64MiB"
+  TX_RESPONSE_MAX_WORKERS: "10"
+  ENABLE_RUNTIME_METRICS: "false"
   # For example:
   # EXAMPLE_ENV: example
 


### PR DESCRIPTION
## Summary

This PR adds conservative memory guardrails for the Core Indexer API to reduce sawtooth-shaped container memory usage and make the service easier to tune under a small pod budget.

Changes include:

- replace the fixed `10,000` entry tx response LRU with a byte-bounded cache controlled by `TX_RESPONSE_CACHE_BYTES`
- bound GCS tx response fetch concurrency with `TX_RESPONSE_MAX_WORKERS`
- cancel remaining GCS tx fetch work on first query error to avoid unnecessary background work
- add configurable DB pool limits for open/idle connections and connection lifetimes
- add Fiber write and idle timeouts to avoid slow/stalled clients holding request resources
- add an optional `/indexer/debug/runtime` endpoint for Go heap, GC, goroutine, and DB pool diagnostics
- add Helm defaults for `GOMEMLIMIT`, `GOGC`, DB pool, HTTP timeout, tx cache, and runtime metrics settings

## Why

The API memory pattern appears to be Go heap/RSS growth and later scavenging rather than pod restarts. The old cache bounded the number of cached tx responses, but not their memory footprint. Since tx responses can vary significantly in size, a fixed-entry cache can still create unpredictable retained memory.

This PR makes the largest retained-memory contributor byte-bounded and adds operational guardrails so memory behavior is more predictable for infra cost optimization.

## Default Runtime Settings

The chart now defaults to conservative values suitable for the current small API pod profile:

```yaml
GOMEMLIMIT: "384MiB"
GOGC: "100"
DB_MAX_OPEN_CONNS: "10"
DB_MAX_IDLE_CONNS: "5"
DB_CONN_MAX_LIFETIME: "30m"
DB_CONN_MAX_IDLE_TIME: "5m"
SERVER_WRITE_TIMEOUT: "30s"
SERVER_IDLE_TIMEOUT: "60s"
TX_RESPONSE_CACHE_BYTES: "64MiB"
TX_RESPONSE_MAX_WORKERS: "10"
ENABLE_RUNTIME_METRICS: "false"
```

## Testing

- `go test ./config ./routes ./services`
- `go test ./...` from `api/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runtime metrics endpoint (goroutines, memory/GC, and DB pool stats), registered when enabled.

* **Configuration**
  * Server write/idle timeouts, DB pool limits/lifetimes, storage cache capacity/workers, and runtime-metrics toggle are configurable via environment (supports byte-size suffixes).

* **Performance**
  * Transaction response caching replaced with a size-aware LRU and controlled worker pool; concurrent fetches use cancellable workflows for safer, faster retrievals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->